### PR TITLE
Futurize for Py3

### DIFF
--- a/django_dag/models.py
+++ b/django_dag/models.py
@@ -5,6 +5,8 @@ Directed Acyclic Graph structure.
 Some ideas stolen from: from https://github.com/stdbrouw/django-treebeard-dag
 
 """
+from past.builtins import basestring
+from builtins import object
 
 from django.db import models
 from django.core.exceptions import ValidationError
@@ -22,7 +24,7 @@ class NodeBase(object):
     Main node abstract model
     """
 
-    class Meta:
+    class Meta(object):
         ordering = ('-id',)
 
     def __unicode__(self):
@@ -90,7 +92,7 @@ class NodeBase(object):
         """
         if cached_results is None:
             cached_results = dict()
-        if self in cached_results.keys():
+        if self in cached_results:
             return cached_results[self]
         else:
             res = set()
@@ -106,7 +108,7 @@ class NodeBase(object):
         """
         if cached_results is None:
             cached_results = dict()
-        if self in cached_results.keys():
+        if self in cached_results:
             return cached_results[self]
         else:
             res = set()
@@ -122,7 +124,7 @@ class NodeBase(object):
         """
         if cached_results is None:
             cached_results = dict()
-        if self in cached_results.keys():
+        if self in cached_results:
             return cached_results[self]
         else:
             res = set()
@@ -138,7 +140,7 @@ class NodeBase(object):
         """
         if cached_results is None:
             cached_results = dict()
-        if self in cached_results.keys():
+        if self in cached_results:
             return cached_results[self]
         else:
             res = set()
@@ -283,7 +285,7 @@ def edge_factory(node_model, child_to_field = "id", parent_to_field = "id", conc
         node_model_name = node_model._meta.model_name
 
     class Edge(base_model):
-        class Meta:
+        class Meta(object):
             abstract = not concrete
 
         parent = models.ForeignKey(node_model, related_name = "%s_child" % node_model_name, to_field = parent_to_field, on_delete=models.CASCADE)
@@ -304,7 +306,7 @@ def node_factory(edge_model, children_null = True, base_model = models.Model):
     Dag Node factory
     """
     class Node(base_model, NodeBase):
-        class Meta:
+        class Meta(object):
             abstract        = True
 
         children  = models.ManyToManyField(

--- a/django_dag/templatetags/dag_tags.py
+++ b/django_dag/templatetags/dag_tags.py
@@ -1,3 +1,4 @@
+from builtins import str
 # dict recurse template tag for django
 # from http://djangosnippets.org/snippets/1974/
 
@@ -37,10 +38,10 @@ class RecurseDictNode(template.Node):
                     output.append(self.renderCallback(context, child_items, level + 1))
                 else:
                     try:
-                        child_items = v.items()
+                        child_items = list(v.items())
                         output.append(self.renderCallback(context, child_items, level + 1))
                     except:
-                        output.append(unicode(v))
+                        output.append(str(v))
 
             if 'endloop' in self.nodeList:
                 output.append(self.nodeList['endloop'].render(context))
@@ -55,7 +56,7 @@ class RecurseDictNode(template.Node):
         return ''.join(output)
 
     def render(self, context):
-        vals = self.var.resolve(context).items()
+        vals = list(self.var.resolve(context).items())
         output = self.renderCallback(context, vals, 1)
         return output
 

--- a/django_dag/tests/models.py
+++ b/django_dag/tests/models.py
@@ -1,3 +1,4 @@
+from builtins import object
 
 from django.db.models import CharField
 from django_dag.models import node_factory, edge_factory
@@ -12,7 +13,7 @@ class ConcreteNode(node_factory('ConcreteEdge')):
     def __str__(self):
         return '# %s' % self.name
 
-    class Meta:
+    class Meta(object):
         app_label = 'django_dag'
 
 
@@ -22,7 +23,7 @@ class ConcreteEdge(edge_factory('ConcreteNode', concrete=False)):
     """
     name = CharField(max_length=32, blank=True, null=True)
 
-    class Meta:
+    class Meta(object):
         app_label = 'django_dag'
 
 

--- a/django_dag/tests/test.py
+++ b/django_dag/tests/test.py
@@ -1,10 +1,11 @@
+from builtins import range
 import multiprocessing
 
 from django.test import TestCase
 from django.shortcuts import render_to_response
 from django.core.exceptions import ValidationError
 from django_dag.tree_test_output import expected_tree_output
-from .models import ConcreteNode, ConcreteEdge
+from django_dag.tests.models import ConcreteNode, ConcreteEdge
 
 
 


### PR DESCRIPTION
`django_dag` was flagged by `caniusepython3` as a package that is not Py3. I did the following to futurize it:

1. Forked the [django-dag](https://github.com/elpaso/django-dag) repo. Now the fork lives at [https://github.com/kinnekcodebase/django-dag](https://github.com/kinnekcodebase/django-dag)
1. Cloned the fork onto my local machine (in my kinnek base directory, level with `dosa`):
    ```
    git clone https://github.com/kinnekcodebase/django-dag.git
    ```
1. Initial attempts to run unit tests failed because of a weird import in one of the test files. I updated `django_dag/tests/test.py` to replace a relative import:
    ```
    from .models import ConcreteNode, ConcreteEdge
    ``` 
    with an absolute import:
    ```
    from django_dag.tests.models import ConcreteNode, ConcreteEdge
    ```
1. Confirmed tests pass before running any futurization:
    ```
    django-admin test --settings=settings
    ```
1. Ran the following futurization in the repo root directory:
    ```
    futurize -0wn .
    ```
1. Fixed some of the automatic futurizations (mostly taking advantage of the default iterator for `dict` instead of using `.keys()`).
1. Reran the unit tests and confirmed they still pass.